### PR TITLE
Add extended backend unit tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests']
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,6 +42,7 @@
     "@typescript-eslint/parser": "^6.19.0",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"
   }

--- a/backend/tests/AnalyticsService.test.ts
+++ b/backend/tests/AnalyticsService.test.ts
@@ -1,0 +1,54 @@
+import { AnalyticsService } from '../src/services/AnalyticsService';
+import { PoolService } from '../src/services/PoolService';
+import { WalletService } from '../src/services/WalletService';
+
+jest.mock('../src/services/PoolService');
+jest.mock('../src/services/WalletService');
+
+const MockedPoolService = PoolService as jest.MockedClass<typeof PoolService>;
+const MockedWalletService = WalletService as jest.MockedClass<typeof WalletService>;
+
+beforeEach(() => {
+  MockedPoolService.mockClear();
+  MockedWalletService.mockClear();
+});
+
+describe('AnalyticsService', () => {
+  it('getPerformance returns metrics with history', async () => {
+    const walletInstance = new WalletService();
+    (walletInstance.getPortfolio as jest.Mock).mockResolvedValue({ totalValue: 1000, solBalance: 1, tokenAccounts: 0, change24h: 0, performance: [] });
+    (WalletService as any).mockImplementation(() => walletInstance);
+
+    const service = new AnalyticsService();
+    const perf = await service.getPerformance('pub', '7d');
+    expect(perf.history.length).toBeGreaterThan(0);
+    expect(perf).toHaveProperty('totalReturn');
+  });
+
+  it('getMarketOverview returns fallback when pools empty', async () => {
+    const poolInstance = new PoolService();
+    (poolInstance.discoverPools as jest.Mock).mockResolvedValue([]);
+    (PoolService as any).mockImplementation(() => poolInstance);
+
+    const service = new AnalyticsService();
+    const overview = await service.getMarketOverview();
+    expect(overview.totalTvl).toBe(0);
+    expect(overview.topPools).toEqual([]);
+  });
+
+  it('getOpportunities filters by risk', async () => {
+    const poolInstance = new PoolService();
+    (poolInstance.discoverPools as jest.Mock).mockResolvedValue([
+      { id: '1', tokenA: 'SOL', tokenB: 'USDC', apy: 20, tvl: 2000000, volume24h: 400000, protocol: 'Raydium' }
+    ]);
+    (poolInstance.getRankings as jest.Mock).mockResolvedValue([
+      { rank: 1, poolId: '1', score: 90, apy: 20, riskScore: 4, liquidityScore: 9 }
+    ]);
+    (PoolService as any).mockImplementation(() => poolInstance);
+
+    const service = new AnalyticsService();
+    const opps = await service.getOpportunities('conservative');
+    expect(opps.length).toBe(1);
+    expect(opps[0].poolId).toBe('1');
+  });
+});

--- a/backend/tests/PoolService.test.ts
+++ b/backend/tests/PoolService.test.ts
@@ -1,0 +1,71 @@
+import axios from 'axios';
+import { PoolService } from '../src/services/PoolService';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('PoolService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('discoverPools should transform and filter Raydium data', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [
+      { ammId: '1', baseMint: 'So11111111111111111111111111111111111111112', quoteMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', liquidity: 200000, volume24h: 10000, apr24h: 5 },
+      { ammId: '2', baseMint: 'TOKENA', quoteMint: 'TOKENB', liquidity: 50000, volume24h: 1000, apr24h: 3 }
+    ]});
+
+    const service = new PoolService();
+    const pools = await service.discoverPools({ minTvl: 100000 });
+
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toEqual(expect.objectContaining({
+      id: '1',
+      tokenA: 'SOL',
+      tokenB: 'USDC',
+      apy: 5,
+      tvl: 200000,
+      protocol: 'Raydium'
+    }));
+  });
+
+  it('getRankings should sort pools by calculated score', async () => {
+    const service = new PoolService();
+    jest.spyOn(service, 'discoverPools').mockResolvedValue([
+      { id: '1', tokenA: 'SOL', tokenB: 'USDC', apy: 10, tvl: 2000000, volume24h: 500000, protocol: 'Raydium' },
+      { id: '2', tokenA: 'SOL', tokenB: 'USDT', apy: 5, tvl: 1000000, volume24h: 100000, protocol: 'Raydium' }
+    ]);
+
+    const rankings = await service.getRankings();
+    expect(rankings[0].score).toBeGreaterThanOrEqual(rankings[1].score);
+    expect(rankings[0].rank).toBe(1);
+    expect(rankings[1].rank).toBe(2);
+  });
+
+  it('analyzePool should return analysis metrics', async () => {
+    const service = new PoolService();
+    jest.spyOn(service, 'discoverPools').mockResolvedValue([
+      { id: 'pool1', tokenA: 'SOL', tokenB: 'USDC', apy: 10, tvl: 2000000, volume24h: 400000, protocol: 'Raydium' }
+    ]);
+
+    const analysis = await service.analyzePool('pool1', {} as any);
+
+    expect(analysis.poolId).toBe('pool1');
+    expect(analysis.impermanentLoss).toHaveProperty('current');
+    expect(analysis.volumeAnalysis).toHaveProperty('trend');
+    expect(analysis.riskMetrics).toHaveProperty('overall');
+  });
+
+  it('discoverPools returns empty array on error', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('fail'));
+    const service = new PoolService();
+    const pools = await service.discoverPools();
+    expect(pools).toEqual([]);
+  });
+
+  it('analyzePool throws when pool missing', async () => {
+    const service = new PoolService();
+    jest.spyOn(service, 'discoverPools').mockResolvedValue([]);
+    await expect(service.analyzePool('none', {} as any)).rejects.toThrow('Pool none not found');
+  });
+});

--- a/backend/tests/WalletService.test.ts
+++ b/backend/tests/WalletService.test.ts
@@ -1,0 +1,47 @@
+const rpcMock = {
+  getAccountInfo: jest.fn(() => ({ send: jest.fn().mockResolvedValue({ value: {} }) })),
+  getBalance: jest.fn(() => ({ send: jest.fn().mockResolvedValue({ value: 2000000000 }) })),
+  getTokenAccountsByOwner: jest.fn(() => ({ send: jest.fn().mockResolvedValue({ value: [] }) }))
+};
+
+import axios from 'axios';
+import { WalletService } from '../src/services/WalletService';
+
+jest.mock('axios');
+jest.mock('@solana/rpc', () => ({
+  createSolanaRpc: jest.fn(() => rpcMock)
+}));
+jest.mock('@solana/addresses', () => ({
+  address: jest.fn(() => 'addr')
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('WalletService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('disconnectWallet should return true', async () => {
+    const service = new WalletService();
+    const result = await service.disconnectWallet('somePublicKey');
+    expect(result).toBe(true);
+  });
+
+  it('connectWallet returns connection info', async () => {
+    const service = new WalletService();
+    const info = await service.connectWallet('pub', 'sig');
+    expect(info.connected).toBe(true);
+    expect(info.balance).toBe(2);
+  });
+
+  it('getPortfolio returns expected balances', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { solana: { usd: 150 } } });
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    const service = new WalletService();
+    const portfolio = await service.getPortfolio('pub');
+    expect(portfolio.totalValue).toBe(300);
+    expect(portfolio.solBalance).toBe(2);
+    expect(portfolio.tokenAccounts).toBe(0);
+  });
+});

--- a/backend/tests/routes.test.ts
+++ b/backend/tests/routes.test.ts
@@ -1,0 +1,115 @@
+import Fastify from 'fastify';
+import { poolRoutes } from '../src/routes/pools';
+import { walletRoutes } from '../src/routes/wallet';
+import { analyticsRoutes } from '../src/routes/analytics';
+import { PoolService } from '../src/services/PoolService';
+import { WalletService } from '../src/services/WalletService';
+import { AnalyticsService } from '../src/services/AnalyticsService';
+
+jest.mock('../src/services/PoolService');
+jest.mock('../src/services/WalletService');
+jest.mock('../src/services/AnalyticsService');
+
+const MockedPoolService = PoolService as jest.MockedClass<typeof PoolService>;
+const MockedWalletService = WalletService as jest.MockedClass<typeof WalletService>;
+const MockedAnalyticsService = AnalyticsService as jest.MockedClass<typeof AnalyticsService>;
+
+describe('API routes', () => {
+  let app: ReturnType<typeof Fastify>;
+  let poolMock: jest.Mocked<PoolService>;
+  let walletMock: jest.Mocked<WalletService>;
+  let analyticsMock: jest.Mocked<AnalyticsService>;
+
+  beforeEach(async () => {
+    poolMock = {
+      discoverPools: jest.fn(),
+      getRankings: jest.fn(),
+      analyzePool: jest.fn()
+    } as any;
+    walletMock = {
+      connectWallet: jest.fn(),
+      getPortfolio: jest.fn(),
+      getPositions: jest.fn(),
+      disconnectWallet: jest.fn()
+    } as any;
+    analyticsMock = {
+      getPerformance: jest.fn(),
+      getMarketOverview: jest.fn(),
+      getOpportunities: jest.fn()
+    } as any;
+
+    MockedPoolService.mockImplementation(() => poolMock);
+    MockedWalletService.mockImplementation(() => walletMock);
+    MockedAnalyticsService.mockImplementation(() => analyticsMock);
+
+    app = Fastify();
+    await app.register(poolRoutes, { prefix: '/api/pools' });
+    await app.register(walletRoutes, { prefix: '/api/wallet' });
+    await app.register(analyticsRoutes, { prefix: '/api/analytics' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/pools/discover returns pools', async () => {
+    poolMock.discoverPools.mockResolvedValue([{ id: '1' } as any]);
+    const res = await app.inject({ method: 'GET', url: '/api/pools/discover' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload).data[0].id).toBe('1');
+  });
+
+  it('GET /api/pools/1/analysis returns analysis', async () => {
+    poolMock.analyzePool.mockResolvedValue({ poolId: '1' } as any);
+    const res = await app.inject({ method: 'GET', url: '/api/pools/1/analysis' });
+    expect(JSON.parse(res.payload).data.poolId).toBe('1');
+  });
+
+  it('POST /api/wallet/connect returns connection', async () => {
+    walletMock.connectWallet.mockResolvedValue({ connected: true } as any);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/wallet/connect',
+      payload: { publicKey: 'p', signature: 's' }
+    });
+    expect(JSON.parse(res.payload).data.connected).toBe(true);
+  });
+
+  it('GET /api/wallet/pk/portfolio returns portfolio', async () => {
+    walletMock.getPortfolio.mockResolvedValue({ totalValue: 1 } as any);
+    const res = await app.inject({ method: 'GET', url: '/api/wallet/pk/portfolio' });
+    expect(JSON.parse(res.payload).data.totalValue).toBe(1);
+  });
+
+  it('GET /api/wallet/pk/positions returns positions', async () => {
+    walletMock.getPositions.mockResolvedValue([{} as any]);
+    const res = await app.inject({ method: 'GET', url: '/api/wallet/pk/positions' });
+    expect(JSON.parse(res.payload).data.length).toBe(1);
+  });
+
+  it('DELETE /api/wallet/pk/disconnect returns true', async () => {
+    walletMock.disconnectWallet.mockResolvedValue(true);
+    const res = await app.inject({ method: 'DELETE', url: '/api/wallet/pk/disconnect' });
+    expect(JSON.parse(res.payload).data.disconnected).toBe(true);
+  });
+
+  it('GET /api/analytics/performance/pk returns metrics', async () => {
+    analyticsMock.getPerformance.mockResolvedValue({ totalReturn: 1 } as any);
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/performance/pk' });
+    expect(JSON.parse(res.payload).data.totalReturn).toBe(1);
+  });
+
+  it('GET /api/analytics/market-overview returns overview', async () => {
+    analyticsMock.getMarketOverview.mockResolvedValue({ totalTvl: 10 } as any);
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/market-overview' });
+    expect(JSON.parse(res.payload).data.totalTvl).toBe(10);
+  });
+
+  it('GET /api/analytics/opportunities returns opportunities', async () => {
+    analyticsMock.getOpportunities.mockResolvedValue([{ poolId: '1' } as any]);
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/opportunities' });
+    expect(JSON.parse(res.payload).data[0].poolId).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- expand `PoolService` tests for error handling
- add more comprehensive `WalletService` tests
- cover Fastify route handlers

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858042fd348832a8a39cf0e03f59f88