### PR TITLE
Add Docker production config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules
+Dockerfile
+**/node_modules
+**/tests
+**/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,6 @@ Thumbs.db
 *.sqlite3
 
 # Docker
-.dockerignore
 
 # Temporary files
 tmp/

--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ nano .env
 
 ### 3. Instalação com Docker (Recomendado)
 ```bash
-# Iniciar todos os serviços
+# Ambiente de desenvolvimento
 docker-compose up -d
 
 # Verificar status
 docker-compose ps
+
+# Para build de produção
+docker-compose -f docker-compose.prod.yml up -d
 ```
 
 ### 4. Instalação Manual

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+src/**/*.test.ts
+tests
+*.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,14 +6,15 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies (skip network issues)
-RUN npm install --no-audit --no-fund || echo "Install completed with warnings"
+# Install dependencies
+RUN npm install --no-audit --no-fund --production || echo "Install completed with warnings"
 
 # Copy source code
 COPY . .
 
-# Expose port
+# Build and expose port
+RUN npm run build
 EXPOSE 3001
 
-# Start the application in development mode
-CMD ["npm", "run", "dev"]
+# Start the application
+CMD ["npm", "start"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,58 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: pollsia
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ./backend
+    ports:
+      - "3001:3001"
+    environment:
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/pollsia
+      REDIS_URL: redis://redis:6379
+      FRONTEND_URL: http://localhost:3000
+      JWT_SECRET: production-secret-change-this
+      NODE_ENV: production
+      PORT: 3001
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+    ports:
+      - "3000:3000"
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:3001/api
+      NEXT_PUBLIC_SOLANA_NETWORK: mainnet-beta
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+src/**/*.test.ts
+tests
+*.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,14 +6,15 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies (skip network issues)
-RUN npm install --no-audit --no-fund || echo "Install completed with warnings"
+# Install dependencies
+RUN npm install --no-audit --no-fund --production || echo "Install completed with warnings"
 
 # Copy source code
 COPY . .
 
-# Expose port
+# Build and expose port
+RUN npm run build
 EXPOSE 3000
 
-# Start in development mode
-CMD ["npm", "run", "dev"]
+# Start the application
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- create `.dockerignore` files and keep them tracked
- update backend and frontend Dockerfiles for production build
- add a `docker-compose.prod.yml` for production usage
- document production docker command in README

## Testing
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_685826416f70832aab23eb89074dee1d